### PR TITLE
pass funcs and consts to the MathExpressionParser explicitly

### DIFF
--- a/pycalc/console_app/parser.py
+++ b/pycalc/console_app/parser.py
@@ -6,7 +6,7 @@ class ArgumentParser:
     @classmethod
     def parse_arguments(cls):
         parser = argparse.ArgumentParser(description='Pure-python command-line calculator.')
-        parser.add_argument('math_expr', type=str, help='mathematic expression')
+        parser.add_argument('expression', type=str, help='mathematic expression')
         parser.add_argument("-m", '--module', nargs="+", default=[], help="module_name")
 
         args = parser.parse_args()

--- a/pycalc/core/recognizer.py
+++ b/pycalc/core/recognizer.py
@@ -1,5 +1,5 @@
-from pycalc.core.available_names import available_functions, available_constants
-from pycalc.core.exceptions import TooManySpaces, TooManyBrackets, TooManyArguments, UnrecognizedOperator, UnrecognizedLexem, \
+from pycalc.core.exceptions import TooManySpaces, TooManyBrackets, TooManyArguments, UnrecognizedOperator, \
+    UnrecognizedLexem, \
     UnrecognizedFunc
 from pycalc.core.operatios import available_operations, available_order_symbols
 from pycalc.core.types import Digit, Operator, MathExpr, Scope, OpenScope, CloseScope
@@ -25,7 +25,7 @@ class ExpressionCalculator:
         return stack[0] if len(stack) == 1 else stack
 
     @classmethod
-    def shunting_yard(cls, parsed_formula):
+    def pops_token_in_right_order(cls, parsed_formula):
         stack = []
         opened_scope = 0
         closed_scope = 0
@@ -60,31 +60,32 @@ class ExpressionCalculator:
 
 
 class MathExpressionParser:
-    def __init__(self, math_expr, rules=None):
-        self.check_spaces(math_expr)
-        self.math_expr = math_expr.replace(" ", "")
-        self.rules = rules
+    def __init__(self, expression, funcs, consts):
+        self.funcs = funcs
+        self.consts = consts
+        self.check_spaces(expression)
+        self.expression = expression.replace(" ", "")
 
-    def check_spaces(self, math_expr):
-        for i, ch in enumerate(math_expr):
+    def check_spaces(self, expression):
+        for i, ch in enumerate(expression):
             t = self.get_type(ch)
             if issubclass(t, Digit) or issubclass(t, MathExpr):
-                if not (i + 2 >= len(math_expr)):
-                    n_ch = math_expr[i + 2]
-                    if math_expr[i + 1] == " " and (
+                if not (i + 2 >= len(expression)):
+                    n_ch = expression[i + 2]
+                    if expression[i + 1] == " " and (
                             issubclass(self.get_type(n_ch), Digit) or issubclass(self.get_type(n_ch), MathExpr)):
                         raise TooManySpaces()
 
             elif issubclass(t, Operator):
                 if ch == "*" or ch == "/":
-                    if not (i + 2 >= len(math_expr)):
-                        n_ch = math_expr[i + 2]
-                        if math_expr[i + 1] == " " and n_ch == ch:
+                    if not (i + 2 >= len(expression)):
+                        n_ch = expression[i + 2]
+                        if expression[i + 1] == " " and n_ch == ch:
                             raise TooManySpaces()
                 elif ch == "<" or ch == ">" or ch == "=":
-                    if not (i + 2 >= len(math_expr)):
-                        n_ch = math_expr[i + 2]
-                        if math_expr[i + 1] == " " and (n_ch == "<" or n_ch == ">" or n_ch == "="):
+                    if not (i + 2 >= len(expression)):
+                        n_ch = expression[i + 2]
+                        if expression[i + 1] == " " and (n_ch == "<" or n_ch == ">" or n_ch == "="):
                             raise TooManySpaces()
 
     def get_type(self, symbol):
@@ -101,11 +102,11 @@ class MathExpressionParser:
         return sym_type
 
     def to_lexems(self):
-        sym_type = self.get_type(self.math_expr[0])
-        lexem = self.math_expr[0]
+        sym_type = self.get_type(self.expression[0])
+        lexem = self.expression[0]
         lexems = []
         add_multiply = False
-        for symbol in self.math_expr[1:]:
+        for symbol in self.expression[1:]:
             next_type = self.get_type(symbol)
             if issubclass(next_type, Scope):
                 if issubclass(sym_type, Digit) and issubclass(next_type, OpenScope):
@@ -158,19 +159,19 @@ class MathExpressionParser:
                 i += 1
                 yield lexem
 
-            elif lexem in available_functions:
+            elif lexem in self.funcs:
                 if lexems[i + 1] not in available_order_symbols:
                     raise UnrecognizedFunc()
                 arguments, pos = self.get_argument_for_function(lexems[i + 2:])
-                func = available_functions[lexem]
+                func = self.funcs[lexem]
                 try:
                     result = func(*arguments)
                     i += pos + 2
                     yield result
                 except TypeError:
                     raise TooManyArguments()
-            elif lexem in available_constants:
-                yield available_constants[lexem]
+            elif lexem in self.consts:
+                yield self.consts[lexem]
                 i += 1
             elif lexem in available_order_symbols:
                 if lexem == "(" or lexem == ")":
@@ -198,12 +199,12 @@ class MathExpressionParser:
                 i += 1
                 if not amount_of_funcs:
                     argument = ExpressionCalculator.calc(
-                        ExpressionCalculator.shunting_yard(self.check_lexems(sub_expression)))
+                        ExpressionCalculator.pops_token_in_right_order(self.check_lexems(sub_expression)))
                     arguments.append(argument)
                     sub_expression = []
                     continue
                 sub_expression.append(lexem)
-            elif lexem in available_functions:
+            elif lexem in self.funcs:
                 amount_of_funcs += 1
                 sub_expression.append(lexem)
                 i += 1
@@ -224,7 +225,7 @@ class MathExpressionParser:
                 i += 1
 
         if sub_expression:
-            argument = ExpressionCalculator.calc(ExpressionCalculator.shunting_yard(self.check_lexems(sub_expression)))
+            argument = ExpressionCalculator.calc(ExpressionCalculator.pops_token_in_right_order(self.check_lexems(sub_expression)))
             if isinstance(argument, list):
                 arguments.extend(argument)
             else:
@@ -258,20 +259,15 @@ class MathExpressionParser:
                     is_changed = self.change_sign(lexem, lexems, i)
                 elif next_lexem in available_operations and next_lexem in ["(", "- ", "+ "]:
                     is_changed = self.change_sign(lexem, lexems, i)
-                elif is_dig or next_lexem in available_constants:
+                elif is_dig or next_lexem in self.consts:
                     is_changed = self.change_sign(lexem, lexems, i)
-                elif next_lexem in available_functions:
+                elif next_lexem in self.funcs:
                     is_changed = self.change_sign(lexem, lexems, i)
 
         return is_changed, lexems
 
 
-def calculation(expr):
-    math_expr = MathExpressionParser(expr)
+def calculation(expr, funcs, consts):
+    math_expr = MathExpressionParser(expr, funcs, consts)
     expr = math_expr.to_lexems()
-    return ExpressionCalculator.calc(ExpressionCalculator.shunting_yard(math_expr.check_lexems(expr)))
-
-
-if __name__ == "__main__":
-    math_expr = MathExpressionParser(".1 * 2.0**56.0")
-    print(math_expr.to_lexems())
+    return ExpressionCalculator.calc(ExpressionCalculator.pops_token_in_right_order(math_expr.check_lexems(expr)))

--- a/pycalc/main.py
+++ b/pycalc/main.py
@@ -9,7 +9,7 @@ def main():
     try:
         for module_name in module_names:
             add_available_names_from_module(available_functions, available_constants, module_name)
-        print(calculation(math_expr))
+        print(calculation(math_expr, available_functions, available_constants))
     except Exception as e:
         print(e)
 

--- a/pycalc/tests/test_calc.py
+++ b/pycalc/tests/test_calc.py
@@ -1,210 +1,216 @@
 import unittest
 from math import *
 
+from pycalc.core.available_names import available_functions, available_constants
 from pycalc.core.recognizer import calculation
 
 
 class GoodTests(unittest.TestCase):
 
     def test_unary_operators(self):
-        self.assertEqual(-13, calculation("-13"))
+        self.assertEqual(-13, calculation("-13", available_functions, available_constants))
 
     def test_unary_operators1(self):
-        self.assertEqual(19, calculation("6-(-13)"))
+        self.assertEqual(19, calculation("6-(-13)", available_functions, available_constants))
 
     def test_unary_operators2(self):
-        self.assertEqual(0, calculation("1---1"))
+        self.assertEqual(0, calculation("1---1", available_functions, available_constants))
 
     def test_unary_operators3(self):
-        self.assertEqual(-1, calculation("-+---+-1"))
+        self.assertEqual(-1, calculation("-+---+-1", available_functions, available_constants))
 
     def test_operation_priority(self):
-        self.assertEqual(5, calculation("1+2*2"))
+        self.assertEqual(5, calculation("1+2*2", available_functions, available_constants))
 
     def test_operation_priority1(self):
-        self.assertEqual(25, calculation("1+(2+3*2)*3"))
+        self.assertEqual(25, calculation("1+(2+3*2)*3", available_functions, available_constants))
 
     def test_operation_priority2(self):
-        self.assertEqual(30, calculation("10*(2+1)"))
+        self.assertEqual(30, calculation("10*(2+1)", available_functions, available_constants))
 
     def test_operation_priority3(self):
-        self.assertEqual(1000, calculation("10**(2+1)"))
+        self.assertEqual(1000, calculation("10**(2+1)", available_functions, available_constants))
 
     def test_operation_priority4(self):
-        self.assertEqual(100 / 3 ** 2, calculation("100/3**2"))
+        self.assertEqual(100 / 3 ** 2, calculation("100/3**2", available_functions, available_constants))
 
     def test_operation_priority5(self):
-        self.assertEqual(100 / 3 % 2 ** 2, calculation("100/3%2**2"))
+        self.assertEqual(100 / 3 % 2 ** 2, calculation("100/3%2**2", available_functions, available_constants))
 
     def test_functions_and_constants(self):
-        self.assertEqual(pi + e, calculation("pi+e"))
+        self.assertEqual(pi + e, calculation("pi+e", available_functions, available_constants))
 
     def test_functions_and_constants1(self):
-        self.assertEqual(1, calculation("log(e)"))
+        self.assertEqual(1, calculation("log(e)", available_functions, available_constants))
 
     def test_functions_and_constants2(self):
-        self.assertEqual(1, calculation("sin(pi/2)"))
+        self.assertEqual(1, calculation("sin(pi/2)", available_functions, available_constants))
 
     def test_functions_and_constants3(self):
-        self.assertEqual(2, calculation("log10(100)"))
+        self.assertEqual(2, calculation("log10(100)", available_functions, available_constants))
 
     def test_functions_and_constants4(self):
-        self.assertEqual(sin(pi / 2) * 1116, calculation("sin(pi/2)1116"))
+        self.assertEqual(sin(pi / 2) * 1116, calculation("sin(pi/2)1116", available_functions, available_constants))
 
     def test_functions_and_constants5(self):
-        self.assertEqual(2, calculation("2*sin(pi/2)"))
+        self.assertEqual(2, calculation("2*sin(pi/2)", available_functions, available_constants))
 
     def test_associative(self):
-        self.assertEqual(102 % 12 % 7, calculation("102%12%7"))
+        self.assertEqual(102 % 12 % 7, calculation("102%12%7", available_functions, available_constants))
 
     def test_associative1(self):
-        self.assertEqual(100 / 4 / 3, calculation("100/4/3"))
+        self.assertEqual(100 / 4 / 3, calculation("100/4/3", available_functions, available_constants))
 
     def test_associative2(self):
-        self.assertEqual(2 ** 3 ** 4, calculation("2**3**4"))
+        self.assertEqual(2 ** 3 ** 4, calculation("2**3**4", available_functions, available_constants))
 
     def test_comparison_operators(self):
-        self.assertEqual(1 + 2 * 3 == 1 + 2 * 3, calculation("1+2*3==1+2*3"))
+        self.assertEqual(1 + 2 * 3 == 1 + 2 * 3, calculation("1+2*3==1+2*3", available_functions, available_constants))
 
     def test_comparison_operators1(self):
-        self.assertEqual(e ** 5 >= e ** 5 + 1, calculation("e**5>=e**5+1"))
+        self.assertEqual(e ** 5 >= e ** 5 + 1, calculation("e**5>=e**5+1", available_functions, available_constants))
 
     def test_comparison_operators2(self):
-        self.assertEqual(1 + 24 // 3 + 1 != 1 + 24 // 3 + 2, calculation("1+24/3+1!=1+24/3+2"))
+        self.assertEqual(1 + 24 // 3 + 1 != 1 + 24 // 3 + 2,
+                         calculation("1+24/3+1!=1+24/3+2", available_functions, available_constants))
 
     def test_common_tests(self):
-        self.assertEqual(100, calculation("(100)"))
+        self.assertEqual(100, calculation("(100)", available_functions, available_constants))
 
     def test_common_tests1(self):
-        self.assertEqual(666, calculation("666"))
+        self.assertEqual(666, calculation("666", available_functions, available_constants))
 
     def test_common_tests2(self):
-        self.assertEqual(30, calculation("10(2+1)"))
+        self.assertEqual(30, calculation("10(2+1)", available_functions, available_constants))
 
     def test_common_tests3(self):
-        self.assertEqual(-0.1, calculation("-.1"))
+        self.assertEqual(-0.1, calculation("-.1", available_functions, available_constants))
 
     def test_common_tests4(self):
-        self.assertEqual(1. / 3, calculation("1/3"))
+        self.assertEqual(1. / 3, calculation("1/3", available_functions, available_constants))
 
     def test_common_tests5(self):
-        self.assertEqual(1.0 / 3.0, calculation("1.0/3.0"))
+        self.assertEqual(1.0 / 3.0, calculation("1.0/3.0", available_functions, available_constants))
 
     def test_common_tests6(self):
-        self.assertEqual(.1 * 2.0 ** 56.0, calculation(".1 * 2.0**56.0"))
+        self.assertEqual(.1 * 2.0 ** 56.0, calculation(".1 * 2.0**56.0", available_functions, available_constants))
 
     def test_common_tests7(self):
-        self.assertEqual(e ** 34, calculation("e**34"))
+        self.assertEqual(e ** 34, calculation("e**34", available_functions, available_constants))
 
     def test_common_tests8(self):
-        self.assertEqual((2.0 ** (pi / pi + e / e + 2.0 ** 0.0)), calculation("(2.0**(pi/pi+e/e+2.0**0.0))"))
+        self.assertEqual((2.0 ** (pi / pi + e / e + 2.0 ** 0.0)),
+                         calculation("(2.0**(pi/pi+e/e+2.0**0.0))", available_functions, available_constants))
 
     def test_common_tests9(self):
         self.assertEqual((2.0 ** (pi / pi + e / e + 2.0 ** 0.0)) ** (1.0 / 3.0),
-                         calculation("(2.0**(pi/pi+e/e+2.0**0.0))**(1.0/3.0)"))
+                         calculation("(2.0**(pi/pi+e/e+2.0**0.0))**(1.0/3.0)", available_functions,
+                                     available_constants))
 
     def test_common_tests10(self):
         self.assertEqual(sin(pi / 2 ** 1) + log(1 * 4 + 2 ** 2 + 1, 3 ** 2),
-                         calculation("sin(pi/2**1) + log(1*4+2**2+1, 3**2)"))
+                         calculation("sin(pi/2**1) + log(1*4+2**2+1, 3**2)", available_functions, available_constants))
 
     def test_common_tests11(self):
         self.assertEqual(10 * e ** 0. * log10(.4 * -5 / -0.1 - 10) - -abs(-53 // 10) + -5,
-                         calculation("10*e^0*log10(.4* -5/ -0.1-10) - -abs(-53//10) + -5"))
+                         calculation("10*e^0*log10(.4* -5/ -0.1-10) - -abs(-53//10) + -5", available_functions,
+                                     available_constants))
 
     def test_common_tests12(self):
-        self.assertEqual(sin(
-            -cos(-sin(3.0) - cos(-sin(-3.0 * 5.0) - sin(cos(log10(43.0)))) + cos(sin(sin(34.0 - 2.0 ** 2.0)))) - -cos(
+        self.assertEqual(
+            sin(-cos(
+                -sin(3.0) - cos(-sin(-3.0 * 5.0) - sin(cos(log10(43.0)))) + cos(sin(sin(34.0 - 2.0 ** 2.0)))) - -cos(
                 1.0) - -cos(0.0) ** 3.0),
             calculation(
-                "sin(-cos(-sin(3.0)-cos(-sin(-3.0*5.0)-sin(cos(log10(43.0))))+cos(sin(sin(34.0-2.0**2.0))))--cos(1.0)--cos(0.0)**3.0)"))
+                "sin(-cos(-sin(3.0)-cos(-sin(-3.0*5.0)-sin(cos(log10(43.0))))"
+                "+cos(sin(sin(34.0-2.0**2.0))))--cos(1.0)--cos(0.0)**3.0)",
+                available_functions, available_constants))
 
     def test_common_tests13(self):
-        self.assertEqual(2.0 ** (2.0 ** 2.0 * 2.0 ** 2.0), calculation("2.0**(2.0**2.0*2.0**2.0)"))
+        self.assertEqual(2.0 ** (2.0 ** 2.0 * 2.0 ** 2.0),
+                         calculation("2.0**(2.0**2.0*2.0**2.0)", available_functions, available_constants))
 
     def test_common_tests14(self):
         self.assertEqual(sin(e ** log(e ** e ** sin(23.0), 45.0) + cos(3.0 + log10(e ** -e))),
-                         calculation("sin(e**log(e**e**sin(23.0),45.0) + cos(3.0+log10(e**-e)))"))
+                         calculation("sin(e**log(e**e**sin(23.0),45.0) + cos(3.0+log10(e**-e)))", available_functions,
+                                     available_constants))
 
     def test_common_tests15(self):
-        self.assertEqual(10, calculation("max(1,2,10,max(1,2,3))"))
+        self.assertEqual(10, calculation("max(1,2,10,max(1,2,3))", available_functions, available_constants))
 
     def test_builtin_func_test15(self):
-        self.assertEqual(1.5, calculation("round(1.5, 1)"))
+        self.assertEqual(1.5, calculation("round(1.5, 1)", available_functions, available_constants))
 
     def test_builtin_func_test16(self):
-        self.assertEqual(4, calculation("pow(2, 2)"))
+        self.assertEqual(4, calculation("pow(2, 2)", available_functions, available_constants))
 
     def test_builtin_func_test17(self):
-        self.assertEqual(1.5, calculation("abs(-1.5)"))
+        self.assertEqual(1.5, calculation("abs(-1.5)", available_functions, available_constants))
 
 
 class RaisesTest(unittest.TestCase):
     def test_raise(self):
-        self.assertRaises(Exception, calculation, "")
+        self.assertRaises(Exception, calculation, "", available_functions, available_constants)
 
     def test_raise1(self):
-        self.assertRaises(Exception, calculation, "+")
+        self.assertRaises(Exception, calculation, "+", available_functions, available_constants)
 
     def test_raise2(self):
-        self.assertRaises(Exception, calculation, "1-")
+        self.assertRaises(Exception, calculation, "1-", available_functions, available_constants)
 
     def test_raise3(self):
-        self.assertRaises(Exception, calculation, "1 2")
+        self.assertRaises(Exception, calculation, "1 2", available_functions, available_constants)
 
     def test_raise4(self):
-        self.assertRaises(Exception, calculation, "ee")
+        self.assertRaises(Exception, calculation, "ee", available_functions, available_constants)
 
     def test_raise5(self):
-        self.assertRaises(Exception, calculation, "123e")
+        self.assertRaises(Exception, calculation, "123e", available_functions, available_constants)
 
     def test_raise6(self):
-        self.assertRaises(Exception, calculation, "==7")
+        self.assertRaises(Exception, calculation, "==7", available_functions, available_constants)
 
     def test_raise7(self):
-        self.assertRaises(Exception, calculation, "1 * * 2")
+        self.assertRaises(Exception, calculation, "1 * * 2", available_functions, available_constants)
 
     def test_raise8(self):
-        self.assertRaises(Exception, calculation, "1 + 2(3 * 4))")
+        self.assertRaises(Exception, calculation, "1 + 2(3 * 4))", available_functions, available_constants)
 
     def test_raise9(self):
-        self.assertRaises(Exception, calculation, "((1+2)")
+        self.assertRaises(Exception, calculation, "((1+2)", available_functions, available_constants)
 
     def test_raise10(self):
-        self.assertRaises(Exception, calculation, "1 + 1 2 3 4 5 6 ")
+        self.assertRaises(Exception, calculation, "1 + 1 2 3 4 5 6 ", available_functions, available_constants)
 
     def test_raise11(self):
-        self.assertRaises(Exception, calculation, "log100(100)")
+        self.assertRaises(Exception, calculation, "log100(100)", available_functions, available_constants)
 
     def test_raise12(self):
-        self.assertRaises(Exception, calculation, "------")
+        self.assertRaises(Exception, calculation, "------", available_functions, available_constants)
 
     def test_raise13(self):
-        self.assertRaises(Exception, calculation, "5 > = 6")
+        self.assertRaises(Exception, calculation, "5 > = 6", available_functions, available_constants)
 
     def test_raise14(self):
-        self.assertRaises(Exception, calculation, "5 / / 6")
+        self.assertRaises(Exception, calculation, "5 / / 6", available_functions, available_constants)
 
     def test_raise15(self):
-        self.assertRaises(Exception, calculation, "6 < = 6")
+        self.assertRaises(Exception, calculation, "6 < = 6", available_functions, available_constants)
 
     def test_raise16(self):
-        self.assertRaises(Exception, calculation, "6 * * 6")
+        self.assertRaises(Exception, calculation, "6 * * 6", available_functions, available_constants)
 
     def test_raise17(self):
-        self.assertRaises(Exception, calculation, "(((((")
+        self.assertRaises(Exception, calculation, "(((((", available_functions, available_constants)
 
     def test_raise18(self):
-        self.assertRaises(Exception, calculation, "sin(1,2)")
+        self.assertRaises(Exception, calculation, "sin(1,2)", available_functions, available_constants)
 
     def test_raise19(self):
-        self.assertRaises(Exception, calculation, "foo(2)")
+        self.assertRaises(Exception, calculation, "foo(2)", available_functions, available_constants)
 
     def test_raise20(self):
-        self.assertRaises(Exception, calculation, "max(1,2,10max(1,2,3))")
+        self.assertRaises(Exception, calculation, "max(1,2,10max(1,2,3))", available_functions, available_constants)
 
     def test_raise21(self):
-        self.assertRaises(Exception, calculation, "sin(,)")
-
-
-if __name__ == '__main__':
-    unittest.main()
+        self.assertRaises(Exception, calculation, "sin(,)", available_functions, available_constants)


### PR DESCRIPTION
Now dict with available functions and constants are passed explicitly to the init method of parser. Test was corrected due to changes.